### PR TITLE
chore: fix github codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,7 @@
 
 # These users are the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.
-* @JackHamer09
-* @itsacoyote
+* @JackHamer09 @itsacoyote
 
 # You can also specify code owners for specific directories or files.
 # For example:


### PR DESCRIPTION
# Description

Fix formatting of github codeowners. 
Having two separate lines with assignees to the same pattern will only use the last defined line's users.