### PR TITLE
feat: demo app resume execution

### DIFF
--- a/apps/demo/src/components/on-ramp-components/RouteSummary.vue
+++ b/apps/demo/src/components/on-ramp-components/RouteSummary.vue
@@ -1,0 +1,62 @@
+<template>
+  <div @click="viewTransaction" class="cursor-pointer border border-gray-400 rounded-2xl flex gap-2 items-center p-2 hover:bg-gray-100 hover:border-gray-500">
+    <div>
+      <TokenIcon :token="route.receive.token" class="w-10 h-10" />
+    </div>
+    <div class="flex flex-col grow">
+      <div class="flex items-center gap-2">
+        <div class="flex items-center">
+          <span>{{payAmount}}</span>
+      <span class="px-1"><Icon icon="fluent:arrow-right-24-regular" /></span>
+      <span>{{ receiveAmount }} {{ route.receive.token.symbol }}</span>
+        </div>
+      </div>
+      <div class="text-[10px]/[12px] text-pretty">
+        {{ lastMessage }}
+      </div>
+    </div>
+    <div>
+      <Icon icon="fluent:chevron-right-24-regular" class="h-10 w-10 text-gray-500" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Icon, } from "@iconify/vue";
+import { storeToRefs, } from "pinia";
+import { computed, } from "vue";
+import type { Route, } from "zksync-easy-onramp-sdk";
+
+import { useOnRampStore, } from "@/stores/on-ramp";
+import { useTransactionStore, } from "@/stores/transaction";
+import { formatFiat, formatToken, } from "@/utils/format-value";
+
+import TokenIcon from "../TokenIcon.vue";
+const props = defineProps<{ route: Route, }>();
+
+const lastMessage = computed(() => {
+  const lastStep = props.route.steps[props.route.steps.length - 1];
+  return lastStep.execution?.process[lastStep.execution.process.length - 1].message;
+},);
+
+const { setStep, } = useOnRampStore();
+const { transaction, } = storeToRefs(useTransactionStore(),);
+const viewTransaction = () => {
+  transaction.value = props.route;
+  setStep("transaction",);
+};
+
+const payAmount = computed(() => {
+  if (props.route) {
+    return formatFiat(props.route.pay.fiatAmount ?? 0, props.route.pay.currency,);
+  }
+  return null;
+},);
+
+const receiveAmount = computed(() => {
+  if (props.route) {
+    return formatToken(props.route.receive.amountUnits ?? 0, props.route.receive.token.decimals,);
+  }
+  return null;
+},);
+</script>

--- a/apps/demo/src/components/on-ramp-views/FormView.vue
+++ b/apps/demo/src/components/on-ramp-views/FormView.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="grow flex flex-col gap-2">
-    <PanelHeader title="Buy" />
+    <PanelHeader title="Buy">
+      <button v-if="hasRoutes" @click="viewRoutes" type="button" class="cursor-pointer p-1 hover:bg-orange-100 rounded-full text-orange-800 hover:text-orange-700">
+        <Icon icon="fluent:book-exclamation-mark-24-regular" class="w-6 h-6" />
+      </button>
+    </PanelHeader>
     <form class="grow flex flex-col space-y-2 gap-2" @submit="getQuotes">
       <div class="flex items-center justify-center">
         <span class="font-semibold text-gray-700 text-3xl -mt-6">$</span>
@@ -51,19 +55,26 @@
 </template>
 
 <script setup lang="ts">
+import { Icon, } from "@iconify/vue";
+import { storeToRefs, } from "pinia";
 import type { Address, } from "viem";
 import {
+  computed,
   onMounted, useTemplateRef, watch,
 } from "vue";
 
 import { useOnRampStore, } from "../../stores/on-ramp";
+import { useRoutesStore, } from "../../stores/routes";
 import PanelHeader from "../widget/PanelHeader.vue";
 
-const { fetchQuotes, } = useOnRampStore();
+const { fetchQuotes, setStep, } = useOnRampStore();
 
 const inputRef = useTemplateRef("input-ref",);
 const fiatAmount = defineModel<number>("fiatAmount", { default: 100, },);
 const address = defineModel<Address>("address", { default: "0x1BDea3773039Fce568CEc019f2C8733CCd0B4431", },);
+
+const { routes, } = storeToRefs(useRoutesStore(),);
+const hasRoutes = computed(() => Object.keys(routes.value,).length > 0,);
 
 const getQuotes = (e: Event,) => {
   e.preventDefault();
@@ -80,6 +91,11 @@ const adjustInputWidth = () => {
     const valueLength = inputRef.value.value.length;
     inputRef.value.style.width = `${valueLength}ch`;
   }
+};
+
+const viewRoutes = () => {
+  // console.log(routes.value,);
+  setStep("transactions",);
 };
 
 watch(() => fiatAmount.value, adjustInputWidth,);

--- a/apps/demo/src/components/on-ramp-views/OrderStatusView.vue
+++ b/apps/demo/src/components/on-ramp-views/OrderStatusView.vue
@@ -23,10 +23,8 @@
 
 <script setup lang="ts">
 import { Icon, } from "@iconify/vue";
-import { useAsyncState, } from "@vueuse/core";
 import { storeToRefs, } from "pinia";
 import { onMounted, ref, } from "vue";
-import { executeRoute, type Route, } from "zksync-easy-onramp-sdk";
 
 import { useOrderProcessingStore, } from "../../stores/order-processing";
 import ProcessStatusIcon from "../on-ramp-components/ProcessStatusIcon.vue";
@@ -35,30 +33,35 @@ import PanelHeader from "../widget/PanelHeader.vue";
 // const { inProgress, isReady, error, results } = storeToRefs(useOrderProcessingStore());
 // const {execute} = useOrderProcessingStore();
 const loading = ref<boolean>(true,);
-const order = ref<Route | null>();
-const { quote, } = storeToRefs(useOrderProcessingStore(),);
+// const order = ref<Route | null>();
+// const { updateRoute, } = useRoutesStore();
 const {
-  state: results,
-  // isReady,
-  isLoading: inProgress,
-  error,
-  execute,
-} = useAsyncState(
-  async () => {
-    if (!quote.value) {
-      throw new Error("No order selected",);
-    }
-    console.log("ordering", quote.value,);
-    return await executeRoute(quote.value, {
-      onUpdateHook: (executingRoute,) => {
-        console.log("exeucting Route", JSON.parse(JSON.stringify(executingRoute,),),);
-        order.value = executingRoute;
-      },
-    },);
-  },
-  null,
-  { immediate: false, },
-);
+  order, error, results, inProgress,
+} = storeToRefs(useOrderProcessingStore(),);
+const { execute, } = useOrderProcessingStore();
+// const {
+//   state: results,
+//   // isReady,
+//   isLoading: inProgress,
+//   error,
+//   execute,
+// } = useAsyncState(
+//   async () => {
+//     if (!quote.value) {
+//       throw new Error("No order selected",);
+//     }
+//     console.log("ordering", quote.value,);
+//     return await executeRoute(quote.value, {
+//       onUpdateHook: (executingRoute,) => {
+//         console.log("exeucting Route", JSON.parse(JSON.stringify(executingRoute,),),);
+//         order.value = executingRoute;
+//         updateRoute(executingRoute,);
+//       },
+//     },);
+//   },
+//   null,
+//   { immediate: false, },
+// );
 
 onMounted(() => {
   setTimeout(() => {

--- a/apps/demo/src/components/on-ramp-views/TransactionView.vue
+++ b/apps/demo/src/components/on-ramp-views/TransactionView.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="flex flex-col gap-2 h-full">
+    <PanelHeader title="Transaction"  back="transactions" />
+    <div class="relative h-full overflow-y-auto" v-if="transaction">
+      <div class="flex gap-2 items-center">
+        <TokenIcon :token="transaction.receive.token" class="w-10 h-10" />
+        <div>
+          <div class="flex items-center">
+          <span>{{payAmount}}</span>
+          <span class="px-1"><Icon icon="fluent:arrow-right-24-regular" /></span>
+          <span>{{ receiveAmount }} {{ transaction.receive.token.symbol }}</span>
+        </div>
+        </div>
+      </div>
+      <div class="pl-12">
+        Purchase via {{ transaction.provider.name }}
+      </div>
+      <div class="text-[10px]/[12px] pl-12 flex gap-2 mt-4 w-[90%] text-pretty">
+        <Icon class="inline-block text-orange-500 w-4 h-4" icon="fluent:warning-16-regular" /> {{ lastMessage }}
+      </div>
+    </div>
+    <div class="flex gap-2">
+      <button @click="restartRoute" type="button" class="cursor-pointer grow w-full bg-blue-500 text-white rounded-full p-2 hover:bg-blue-600">
+        Try again
+      </button>
+      <button @click="removeTransaction" type="button" class="cursor-pointer shrink bg-red-600/70 text-white rounded-full px-3 p-2 hover:bg-red-600">
+        <Icon icon="fluent:delete-24-regular" class="w-6 h-6" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Icon, } from "@iconify/vue";
+import { storeToRefs, } from "pinia";
+import { computed, } from "vue";
+
+import { useOnRampStore, } from "@/stores/on-ramp";
+import { useOrderProcessingStore, } from "@/stores/order-processing";
+import { useRoutesStore, } from "@/stores/routes";
+import { useTransactionStore, } from "@/stores/transaction";
+import { formatFiat, formatToken, } from "@/utils/format-value";
+
+import TokenIcon from "../TokenIcon.vue";
+import PanelHeader from "../widget/PanelHeader.vue";
+
+const { transaction, } = storeToRefs(useTransactionStore(),);
+const lastMessage = computed(() => {
+  const lastStep = transaction.value?.steps[transaction.value.steps.length - 1];
+  return lastStep?.execution?.process[lastStep.execution.process.length - 1].message;
+},);
+
+const payAmount = computed(() => {
+  if (transaction.value) {
+    return formatFiat(transaction.value.pay.fiatAmount ?? 0, transaction.value.pay.currency,);
+  }
+  return null;
+},);
+
+const receiveAmount = computed(() => {
+  if (transaction.value) {
+    return formatToken(transaction.value.receive.amountUnits ?? 0, transaction.value.receive.token.decimals,);
+  }
+  return null;
+},);
+
+const { setStep, } = useOnRampStore();
+const { removeRoute, } = useRoutesStore();
+const removeTransaction = () => {
+  const routeId = transaction.value!.id;
+  removeRoute(routeId,);
+  setStep("transactions",);
+};
+
+const { selectQuote, } = useOrderProcessingStore();
+const restartRoute = () => {
+  selectQuote(transaction.value!,);
+  setStep("processing",);
+};
+
+</script>

--- a/apps/demo/src/components/on-ramp-views/TransactionsView.vue
+++ b/apps/demo/src/components/on-ramp-views/TransactionsView.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="flex flex-col gap-2 h-full">
+    <PanelHeader title="Active Transactions"  back="buy" />
+    <div class="relative h-full overflow-y-auto">
+      <div v-for="route in routes" :key="route.id">
+        <RouteSummary :route="route" class="my-2" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs, } from "pinia";
+import { onMounted, } from "vue";
+
+import { useOnRampStore, } from "@/stores/on-ramp";
+
+import { useRoutesStore, } from "../../stores/routes";
+import RouteSummary from "../on-ramp-components/RouteSummary.vue";
+import PanelHeader from "../widget/PanelHeader.vue";
+const { routes, } = storeToRefs(useRoutesStore(),);
+
+const { setStep, } = useOnRampStore();
+onMounted(() => {
+  if (routes.value.length === 0) {
+    setStep("buy",);
+  }
+},);
+</script>

--- a/apps/demo/src/components/widget/PanelHeader.vue
+++ b/apps/demo/src/components/widget/PanelHeader.vue
@@ -19,6 +19,7 @@
       </button>
     </div>
     <h2 class="text-lg font-semibold text-center">{{ props.title }}</h2>
+    <div class="absolute right-0 top-0"><slot /></div>
   </div>
 </template>
 

--- a/apps/demo/src/components/widget/WidgetPanel.vue
+++ b/apps/demo/src/components/widget/WidgetPanel.vue
@@ -2,9 +2,11 @@
   <div class="border border-gray-200 rounded-2xl shadow-xl w-panel-width relative h-panel-height">
     <div class="absolute inset-0 p-4 flex flex-col justify-stretch items-stretch">
       <Transition mode="out-in">
-        <BuyView v-if="step === 'buy'" />
+        <FormView v-if="step === 'buy'" />
         <QuotesView v-else-if="step === 'quotes'" />
         <OrderStatusView v-else-if="step === 'processing'" />
+        <TransactionsView v-else-if="step === 'transactions'" />
+        <TransactionView v-else-if="step === 'transaction'" />
       </Transition>
     </div>
   </div>
@@ -14,9 +16,11 @@
 import { storeToRefs, } from "pinia";
 
 import { useOnRampStore, } from "../../stores/on-ramp";
-import BuyView from "../on-ramp-views/BuyView.vue";
+import FormView from "../on-ramp-views/FormView.vue";
 import OrderStatusView from "../on-ramp-views/OrderStatusView.vue";
 import QuotesView from "../on-ramp-views/QuotesView.vue";
+import TransactionsView from "../on-ramp-views/TransactionsView.vue";
+import TransactionView from "../on-ramp-views/TransactionView.vue";
 
 const { step, } = storeToRefs(useOnRampStore(),);
 </script>

--- a/apps/demo/src/stores/on-ramp.ts
+++ b/apps/demo/src/stores/on-ramp.ts
@@ -4,7 +4,7 @@ import type { FetchQuoteParams, } from "zksync-easy-onramp-sdk";
 
 import { useQuotesStore, } from "./quotes";
 
-export type Steps = "buy" | "quotes" | "processing";
+export type Steps = "buy" | "quotes" | "processing" | "transactions" | "transaction";
 
 export const useOnRampStore = defineStore("on-ramp", () => {
   const step = ref<Steps>("buy",);

--- a/apps/demo/src/stores/order-processing.ts
+++ b/apps/demo/src/stores/order-processing.ts
@@ -1,38 +1,63 @@
 import { useAsyncState, } from "@vueuse/core";
 import { defineStore, } from "pinia";
 import { ref, } from "vue";
-import type { ProviderQuoteOption, } from "zksync-easy-onramp-sdk";
-import { executeRoute, } from "zksync-easy-onramp-sdk";
+import type { ProviderQuoteOption, Route, } from "zksync-easy-onramp-sdk";
+import { executeRoute, resumeExecution, } from "zksync-easy-onramp-sdk";
+
+import { useRoutesStore, } from "./routes";
 
 export const useOrderProcessingStore = defineStore("order-processing", () => {
-  const quote = ref<ProviderQuoteOption | null>(null,);
+  const { updateRoute, removeRoute, } = useRoutesStore();
+  const order = ref<Route | null>(null,);
+
+  const onUpdateHook = (executingRoute: Route,) => {
+    console.log("executing Route", JSON.parse(JSON.stringify(executingRoute,),),);
+    updateRoute(executingRoute,);
+    order.value = executingRoute;
+  };
+
   const {
     state: results,
-    isReady,
+    // isReady,
     isLoading: inProgress,
     error,
     execute,
   } = useAsyncState(
     async () => {
-      if (!quote.value) {
+      if (!order.value) {
         throw new Error("No order selected",);
       }
-      console.log("ordering", quote.value,);
-      await executeRoute(quote.value,);
+      console.log("ordering", order.value,);
+      if (order.value.id) {
+        console.log("RESUMING", order.value.id,);
+        return await resumeExecution(order.value, { onUpdateHook, },);
+      } else {
+        console.log("EXECUTING", order.value,);
+        return await executeRoute(order.value, { onUpdateHook, },);
+      }
+
     },
     null,
-    { immediate: false, },
+    {
+      immediate: false,
+      onSuccess: (completedRoute: Route,) => {
+        updateRoute(completedRoute,);
+        removeRoute(completedRoute.id,);
+      },
+      onError: (error,) => {
+        console.error("error", error,);
+      },
+    },
   );
 
-  function selectQuote(route: ProviderQuoteOption,) {
-    quote.value = route;
+  function selectQuote(route: ProviderQuoteOption | Route,) {
+    order.value = route as Route;
   }
 
   return {
-    quote,
+    order,
     execute,
     inProgress,
-    isReady,
     error,
     results,
     selectQuote,

--- a/apps/demo/src/stores/routes.ts
+++ b/apps/demo/src/stores/routes.ts
@@ -1,0 +1,28 @@
+import { useStorage, } from "@vueuse/core";
+import { defineStore, } from "pinia";
+import { computed, } from "vue";
+import type { Route, } from "zksync-easy-onramp-sdk";
+
+export const useRoutesStore = defineStore("routes", () => {
+  const _routes = useStorage<Record<Route["id"], Route>>("onramp-routes", {},);
+
+  const routes = computed(() => {
+    return Object.values(_routes.value,);
+  },);
+
+  const updateRoute = (route: Route,) => {
+    if (route.id) {
+      _routes.value[route.id] = route;
+    }
+  };
+
+  const removeRoute = (routeId: string,) => {
+    if (routeId) {
+      delete _routes.value[routeId];
+    }
+  };
+
+  return {
+    routes, updateRoute, removeRoute,
+  };
+},);

--- a/apps/demo/src/stores/transaction.ts
+++ b/apps/demo/src/stores/transaction.ts
@@ -1,0 +1,9 @@
+import { defineStore, } from "pinia";
+import {  ref, } from "vue";
+import type { Route, } from "zksync-easy-onramp-sdk";
+
+export const useTransactionStore = defineStore("transaction", () => {
+  const transaction = ref<Route | null>(null,);
+
+  return { transaction, };
+},);

--- a/apps/demo/src/utils/format-value.ts
+++ b/apps/demo/src/utils/format-value.ts
@@ -1,0 +1,11 @@
+import { formatUnits, } from "viem";
+
+export const formatFiat = function (value: number, currency: string,) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency, },).format(value,);
+};
+
+export const formatToken = function (value: number | string, decimals: number,) {
+  const bigValue = BigInt(value,);
+
+  return parseFloat(formatUnits(bigValue, decimals,),).toFixed(6,);
+};

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -17,15 +17,6 @@
         gap: 1rem;
       "
     >
-      <label for="chain">Chain:</label>
-      <select id="chain" name="chain">
-        <option value="1">Ethereum</option>
-      </select>
-      <label for="from-currency">From Token:</label>
-      <select id="from-currency" name="from-currency">
-        <option value="usd">USD</option>
-      </select>
-
       <label for="fiat-amount">Amount:</label>
       <input
         type="number"
@@ -36,11 +27,10 @@
         value="100"
         required
       />
-      <hr style="border: 1px solid black; width: 100%" />
       <label for="to-token">To Token:</label>
       <select id="to-token" name="to-token">
         <option value="0x0000000000000000000000000000000000000000">ETH</option>
-        <option value="0xAFe4cA0Bbe6215cBdA12857e723134Bc3809F766">MCRN</option>
+        <option value="0xB8c77482e45F1F44dE1745F52C74426C631bDD52">BNB</option>
         <option value="0xe1134444211593Cfda9fc9eCc7B43208615556E2">UNI</option>
       </select>
 

--- a/packages/sdk/src/core/execution.ts
+++ b/packages/sdk/src/core/execution.ts
@@ -49,7 +49,7 @@ function stopRouteExecution(executingRoute: Route,) {
   return executionData.route;
 }
 
-export async function resumeExecution(route: Route,) {
+export async function resumeExecution(route: Route, executionOptions?: ExecutionOptions,) {
   if (!route.id) {
     throw new Error("Quote does not have an id. Please call executeRoute instead.",);
   }
@@ -61,7 +61,7 @@ export async function resumeExecution(route: Route,) {
 
   const restartedRoute = await restartRoute(route,);
 
-  return executeRoute(restartedRoute,);
+  return executeRoute(restartedRoute, executionOptions,);
 }
 
 async function restartRoute(route: Route,): Promise<Route> {

--- a/packages/sdk/src/dev.ts
+++ b/packages/sdk/src/dev.ts
@@ -10,9 +10,8 @@ form?.addEventListener("submit", async (event,) => {
   event.preventDefault();
   const formData = new FormData(form as HTMLFormElement,);
   const fiatAmount = formData.get("fiat-amount",) as string | undefined;
-  // const currency = formData.get("from-currency",);
   const toAddress = formData.get("address",);
-  const fromChain = formData.get("chain",);
+  const fromChain = 1;
   const toToken = formData.get("to-token",);
 
   // const order = document.querySelector("#order",);


### PR DESCRIPTION
# Description

Allows for resuming a route that was interrupted, for example closing the payment window before completion or refreshing the page. Status states in processes for restarting are not 100% working correctly, fixing that in subsequent PRs



https://github.com/user-attachments/assets/df059e3e-85a2-4984-a818-80f19e146d44

