### PR TITLE
chore: add nodejs license check workflow

### DIFF
--- a/.github/workflows/nodejs-license.yaml
+++ b/.github/workflows/nodejs-license.yaml
@@ -1,0 +1,61 @@
+name: 🪪 Node license check
+
+on: pull_request
+
+env:
+  ALLOWED_LICENSES: >
+    MIT;
+    BSD;
+    ISC;
+    Apache-2.0;
+    MPL-2.0;
+    LGPL-3.0;
+    LGPL-3.0-or-later;
+    CC0-1.0;
+    CC-BY-3.0;
+    CC-BY-4.0;
+    Python-2.0;
+    PSF;
+    Public Domain;
+    WTFPL;
+    Unlicense;
+    BlueOak-1.0.0;
+
+jobs:
+  generate-matrix:
+    name: Lists modules
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - run: |
+          DIRS=$(find -not \( -path \*node_modules -prune \) -type f -name package-lock.json  | xargs dirname | awk -v RS='' -v OFS='","' 'NF { $1 = $1; print "\"" $0 "\"" }')
+          echo "matrix=[${DIRS}]" >> $GITHUB_OUTPUT
+        id: set-matrix
+
+  license-check:
+    needs: [generate-matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dir: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: 18
+
+      - name: Install license-checker
+        run: npm install -g license-checker
+
+      - name: Install dependencies in ${{ matrix.dir }}
+        working-directory: ${{ matrix.dir }}
+        run: npm ci -w zksync-easy-onramp server
+
+      - name: Check licenses in ${{ matrix.dir }}
+        working-directory: ${{ matrix.dir }}
+        run: npx license-checker --json --onlyAllow="$ALLOWED_LICENSES" --excludePackages "$EXCLUDE_PACKAGES" --excludePrivatePackages


### PR DESCRIPTION
# Description

Add workflow for checking nodejs licenses. 
This runs on licenses for packages used in the SDK and server. 
It does not check the demo app.