### PR TITLE
chore: add publish flag to release workflow

### DIFF
--- a/.changeset/big-flowers-occur.md
+++ b/.changeset/big-flowers-occur.md
@@ -1,0 +1,5 @@
+---
+"zksync-easy-onramp": patch
+---
+
+Add publish flag to release workflow to remove console logs from production build of the sdk.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These users are the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.
-* @JackHamer09 @itsacoyote
+* @JackHamer09 @itsacoyote @yuliyaalexiev @matter-labs/devxp
 
 # You can also specify code owners for specific directories or files.
 # For example:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 env:
   HUSKY: 0
   CI: true
+  PUBLISH: true
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -16,7 +16,7 @@ export function createOnRampConfig(configOptions: ConfigOptions,): SDKConfig {
 export const config = (() => {
   const _config: SDKConfig = {
     integrator: "zksync easy-onramp",
-    apiUrl: "https://easy-onramp-api.zksync.dev",
+    apiUrl: "https://easy-onramp-api.zksync.dev/api",
     services: [],
     provider: null,
     dev: false,


### PR DESCRIPTION
# Description

Add the publish flag to release workflow. This is used for simple things like removing console.log when building the sdk package.