### PR TITLE
chore: use npm to start server in docker

### DIFF
--- a/packages/server/apps/api/Dockerfile
+++ b/packages/server/apps/api/Dockerfile
@@ -58,4 +58,4 @@ HEALTHCHECK --interval=30s --timeout=3s --retries=5 \
   CMD curl -f http://localhost:${PORT}/api/health || exit 1
 
 # Run the application
-CMD [ "node", "packages/server/dist/apps/api/apps/api/src/main.js" ]
+CMD [ "npm", "run", "start", "-w=server" ]

--- a/packages/server/libs/db/src/typeorm.config.ts
+++ b/packages/server/libs/db/src/typeorm.config.ts
@@ -5,6 +5,7 @@ import { DataSource, } from "typeorm";
 import config from "./config";
 import * as Entities from "./entities";
 
+console.log(`Current working directory: ${process.cwd()}`,);
 const dataSourceOptions: DataSourceOptions = {
   type: "postgres",
   host: config.db.host || "localhost",


### PR DESCRIPTION
# Description
Use npm to start server in docker

## Additional context
Previously server was started from the root of the repo, which cause migrations to look for files at the wrong place, resulting in no migrations being run. Using `npm run start -w=server` makes sure the working directory is `packages/server`