### PR TITLE
fix: quote by payment method

### DIFF
--- a/packages/sdk/src/core/executionState.ts
+++ b/packages/sdk/src/core/executionState.ts
@@ -78,8 +78,10 @@ function generateIds(route: ProviderQuoteOption | Route,): Route {
   if (!route.id) {
     const id = uuidv4();
     route.id = id;
-    route.steps.forEach((step,index,) => {
-      (step as StepExtended).id = `${id}:${index}`;
+    route.paymentMethods.forEach((paymentMethod,) => {
+      paymentMethod.steps.forEach((step,index,) => {
+        (step as StepExtended).id = `${id}:${index}`;
+      },);
     },);
   }
   return route as Route;

--- a/packages/sdk/src/dev.ts
+++ b/packages/sdk/src/dev.ts
@@ -78,39 +78,47 @@ form?.addEventListener("submit", async (event,) => {
   resultsList.innerHTML = ""; // Clear previous results
 
   results.quotes.forEach((quote,) => {
-    const li = document.createElement("li",);
-    const button = document.createElement("button",);
-    // button.textContent = "Execute Quote: " + quote.steps.length + " steps";
-    button.textContent = `[${quote.provider.name}] Receive: ${quote.receive.amountFiat}$ in ${quote.steps.length} steps`;
-    button.addEventListener("click", async () => {
-      const results = await executeRoute(quote, {
-        onUpdateHook: (route: Route,) => {
-          const orderStatusList = document.querySelector("#order-status",);
-          if (orderStatusList) {
-            orderStatusList.innerHTML = ""; // Clear previous status
+    const ulProviders = document.createElement("ul",);
+    const span = document.createElement("b",);
+    span.textContent = quote.provider.name;
+    ulProviders.appendChild(span,);
 
-            route.steps.forEach((step, index,) => {
-              const stepLi = document.createElement("li",);
-              stepLi.textContent = `Step ${index + 1}: ${step.type}`;
+    quote.paymentMethods.forEach((paymentMethodQuote,) => {
+      const li = document.createElement("li",);
+      const button = document.createElement("button",);
+      button.textContent = `[${paymentMethodQuote.method}] Receive: ${paymentMethodQuote.receive.amountFiat}$ in ${paymentMethodQuote.steps.length} steps`;
+      button.addEventListener("click", async () => {
+        const results = await executeRoute(quote, {
+          onUpdateHook: (route: Route,) => {
+            const orderStatusList = document.querySelector("#order-status",);
+            if (orderStatusList) {
+              orderStatusList.innerHTML = ""; // Clear previous status
 
-              const processUl = document.createElement("ul",);
-              if (step.execution) {
-                step.execution!.process.forEach((process,) => {
-                  const processLi = document.createElement("li",);
-                  processLi.textContent = `Status: ${process.status}, Message: ${process.message}`;
-                  processUl.appendChild(processLi,);
-                },);
-              }
+              route.steps.forEach((step, index,) => {
+                const stepLi = document.createElement("li",);
+                stepLi.textContent = `Step ${index + 1}: ${step.type}`;
 
-              stepLi.appendChild(processUl,);
-              orderStatusList.appendChild(stepLi,);
-            },);
-          }
-        },
+                const processUl = document.createElement("ul",);
+                if (step.execution) {
+                  step.execution!.process.forEach((process,) => {
+                    const processLi = document.createElement("li",);
+                    processLi.textContent = `Status: ${process.status}, Message: ${process.message}`;
+                    processUl.appendChild(processLi,);
+                  },);
+                }
+
+                stepLi.appendChild(processUl,);
+                orderStatusList.appendChild(stepLi,);
+              },);
+            }
+          },
+        },);
+        console.log("Final results:", JSON.parse(JSON.stringify(results,),),);
       },);
-      console.log("Final results:", JSON.parse(JSON.stringify(results,),),);
+      li.appendChild(button,);
+      ulProviders.appendChild(li,);
     },);
-    li.appendChild(button,);
-    resultsList.appendChild(li,);
+
+    resultsList.appendChild(ulProviders,);
   },);
 },);

--- a/packages/sdk/src/dev.ts
+++ b/packages/sdk/src/dev.ts
@@ -27,7 +27,7 @@ createOnRampConfig({
   integrator: "Dev Demo",
   apiUrl: "http://localhost:3020/api",
   services: [ "kado", "transak", ],
-  dev: false,
+  dev: true,
   provider: EVM({
     getWalletClient: async () => client,
     switchChain: async (chainId,) =>

--- a/packages/sdk/src/types/server.ts
+++ b/packages/sdk/src/types/server.ts
@@ -22,12 +22,12 @@ export enum QuoteProviderType {
 }
 
 export enum PaymentMethod {
-  CREDIT_CARD = "credit_card",
   APPLE_PAY_CREDIT = "apple_pay_credit",
   GOOGLE_PAY_CREDIT = "google_pay_credit",
-  DEBIT_CARD = "debit_card",
   APPLE_PAY_DEBIT = "apple_pay_debit",
   GOOGLE_PAY_DEBIT = "google_pay_debit",
+  CREDIT_CARD = "credit_card",
+  DEBIT_CARD = "debit_card",
   WIRE = "wire",
   PIX = "pix",
   SEPA = "sepa",
@@ -79,10 +79,8 @@ export type QuoteStepTokenSwap = {
 
 export type QuoteStep = QuoteStepOnrampViaLink | QuoteStepTokenSwap;
 
-export interface ProviderQuoteOption {
-  id?: string;
-  type: RouteType;
-  provider: Provider;
+export interface PaymentMethodQuote {
+  method: PaymentMethod;
   pay: {
     currency: string;
     fiatAmount: number;
@@ -102,10 +100,15 @@ export interface ProviderQuoteOption {
     amountUnits: string;
     amountFiat: number;
   };
-  paymentMethods: PaymentMethod[];
   kyc: KycRequirement[];
   steps: QuoteStep[];
+}
+export interface ProviderQuoteOption {
+  id?: string;
+  type: RouteType;
+  provider: Provider;
   country?: string;
+  paymentMethods: PaymentMethodQuote[];
 };
 
 export type QuotesResponse = {

--- a/packages/server/apps/api/src/config-controller/config.controller.ts
+++ b/packages/server/apps/api/src/config-controller/config.controller.ts
@@ -1,9 +1,9 @@
 import { supportedChains, } from "@app/common/chains";
 import { supportedFiatCurrencies, } from "@app/common/currencies";
-import { Token, } from "@app/db/entities";
 import { SupportedTokenRepository, } from "@app/db/repositories";
 import { ProvidersRegistry, } from "@app/providers";
 import { TokensService, } from "@app/tokens";
+import { mapTokenPublicData, } from "@app/tokens/utils";
 import {
   Controller,
   Get,
@@ -27,16 +27,6 @@ export class ConfigController {
   @ApiResponse({ type: ConfigResponseDto, },)
   @UsePipes(new ValidationPipe({ transform: true, },),)
   async getConfig(): Promise<ConfigResponseDto> {
-    const mapTokenPublicData = (token: Token,) => ({
-      chainId: token.chainId,
-      address: token.address,
-      decimals: token.decimals,
-      symbol: token.symbol,
-      name: token.name,
-      marketCap: token.marketCap,
-      usdPrice: token.usdPrice,
-      iconUrl: token.iconUrl,
-    });
     const [ tokens, supportedTokens, ] = await Promise.all([
       this.tokensService.getAll(),
       this.supportedTokenRepository.find({ relations: ["token",], },),

--- a/packages/server/libs/common/src/quotes/helpers.ts
+++ b/packages/server/libs/common/src/quotes/helpers.ts
@@ -1,0 +1,10 @@
+import type { PaymentMethodQuoteDto, } from "./quotes.dto";
+
+export const findBestQuote = (quotesByPaymentMethod: PaymentMethodQuoteDto[],): PaymentMethodQuoteDto => {
+  return quotesByPaymentMethod.reduce((bestQuote, quote,) => {
+    if (quote.receive.amountFiat > bestQuote.receive.amountFiat) {
+      return quote;
+    }
+    return bestQuote;
+  }, quotesByPaymentMethod[0],);
+};

--- a/packages/server/libs/common/src/quotes/index.ts
+++ b/packages/server/libs/common/src/quotes/index.ts
@@ -1,1 +1,2 @@
+export * from "./helpers";
 export * from "./quotes.dto";

--- a/packages/server/libs/common/src/quotes/quotes.dto.ts
+++ b/packages/server/libs/common/src/quotes/quotes.dto.ts
@@ -2,6 +2,7 @@ import { Token, } from "@app/db/entities";
 import {
   KycRequirement, PaymentMethod, QuoteProviderType, RouteType,
 } from "@app/db/enums";
+import { TokenData, } from "@app/tokens";
 import { LiFiStep, } from "@lifi/sdk";
 import {
   IsArray,
@@ -105,6 +106,32 @@ export type QuoteStepTokenSwap = {
 
 export type QuoteStep = QuoteStepOnrampViaLink | QuoteStepTokenSwap;
 
+export class QuotePay {
+  currency: string;
+  fiatAmount: number;
+  totalFeeFiat: number;
+  minAmountUnits?: string;
+  minAmountFiat?: number;
+  maxAmountUnits?: string;
+  maxAmountFiat?: number;
+}
+export class QuoteReceive {
+  token: TokenData;
+  chain: {
+    id: number;
+    name: string;
+  };
+  to: Address;
+  amountUnits: string;
+  amountFiat: number;
+}
+export class PaymentMethodQuoteDto {
+  method: PaymentMethod;
+  pay: QuotePay;
+  receive: QuoteReceive;
+  steps: QuoteStep[];
+  kyc: KycRequirement[];
+};
 export class ProviderQuoteDto {
   type: RouteType;
   provider: {
@@ -113,34 +140,8 @@ export class ProviderQuoteDto {
     name: string;
     iconUrl: string;
   };
-  pay: {
-    currency: string;
-    fiatAmount: number;
-    totalFeeFiat: number;
-    minAmountUnits?: string;
-    minAmountFiat?: number;
-    maxAmountUnits?: string;
-    maxAmountFiat?: number;
-  };
-  receive: {
-    token: {
-      address: string;
-      symbol: string;
-      name: string;
-      decimals: number;
-    };
-    chain: {
-      id: number;
-      name: string;
-    };
-    to: Address;
-    amountUnits: string;
-    amountFiat: number;
-  };
-  paymentMethods: PaymentMethod[];
-  kyc: KycRequirement[];
-  steps: QuoteStep[];
   country?: string;
+  paymentMethods: PaymentMethodQuoteDto[];
 }
 
 export class QuoteResponseDto {

--- a/packages/server/libs/db/src/enums/index.ts
+++ b/packages/server/libs/db/src/enums/index.ts
@@ -9,12 +9,12 @@ export enum QuoteProviderType {
 }
 
 export enum PaymentMethod {
-  CREDIT_CARD = "credit_card",
   APPLE_PAY_CREDIT = "apple_pay_credit",
   GOOGLE_PAY_CREDIT = "google_pay_credit",
-  DEBIT_CARD = "debit_card",
   APPLE_PAY_DEBIT = "apple_pay_debit",
   GOOGLE_PAY_DEBIT = "google_pay_debit",
+  CREDIT_CARD = "credit_card",
+  DEBIT_CARD = "debit_card",
   WIRE = "wire",
   PIX = "pix",
   SEPA = "sepa",

--- a/packages/server/libs/providers/src/provider.interface.ts
+++ b/packages/server/libs/providers/src/provider.interface.ts
@@ -10,5 +10,5 @@ export interface IProvider {
   };
 
   syncRoutes(): Promise<void>;
-  getQuote(options: QuoteOptions): Promise<ProviderQuoteDto[]>;
+  getQuote(options: QuoteOptions): Promise<ProviderQuoteDto | null>;
 }

--- a/packages/server/libs/providers/src/providers-quote.service.ts
+++ b/packages/server/libs/providers/src/providers-quote.service.ts
@@ -68,13 +68,13 @@ export class ProvidersQuoteService {
     };
   }
 
-  async getProviderQuotes(providerKey: string, options: QuoteOptions,): Promise<ProviderQuoteDto[]> {
+  async getProviderQuote(providerKey: string, options: QuoteOptions,): Promise<ProviderQuoteDto | null> {
     await this.waitForStateReady();
 
     const provider = this.providersRegistry.providers.find((e,) => e.meta.key === providerKey,);
     if (!provider) throw new BadRequestException("Provider not found",);
 
-    const quotes = await provider.getQuote(options,);
-    return quotes;
+    const quote = await provider.getQuote(options,);
+    return quote;
   }
 }

--- a/packages/server/libs/providers/src/providers/kado/kado.provider.ts
+++ b/packages/server/libs/providers/src/providers/kado/kado.provider.ts
@@ -2,6 +2,7 @@ import {
   isChainIdSupported, SupportedChainId, supportedChains,
 } from "@app/common/chains";
 import {
+  PaymentMethodQuoteDto,
   ProviderQuoteDto, QuoteOptions, QuoteStepOnrampViaLink,
 } from "@app/common/quotes";
 import { TimedCache, } from "@app/common/utils/timed-cache";
@@ -14,6 +15,7 @@ import {
   ProviderRepository, SupportedCountryRepository, SupportedKycRepository, SupportedTokenRepository, 
 } from "@app/db/repositories";
 import { TokensService, } from "@app/tokens";
+import { mapTokenPublicData, } from "@app/tokens/utils";
 import { Injectable, Logger, } from "@nestjs/common";
 import { ConfigService, } from "@nestjs/config";
 import { $fetch, } from "ofetch";
@@ -238,7 +240,7 @@ export class KadoProvider implements IProvider {
     }
   }
 
-  async getQuote(options: QuoteOptions,): Promise<ProviderQuoteDto[]> {
+  async getQuote(options: QuoteOptions,): Promise<ProviderQuoteDto | null> {
     const chain = supportedChains.find((chain,) => chain.id === options.chainId,)!;
 
     const query = {
@@ -266,7 +268,7 @@ export class KadoProvider implements IProvider {
 
     if (!response.success) {
       this.logger.error(`Failed to get quote from ${this.meta.name} for ${url}. Error: ${response.message}`,);
-      return [];
+      return null;
     }
 
     const baseData = {
@@ -284,7 +286,6 @@ export class KadoProvider implements IProvider {
       kadoChainKey: chainIdToKadoChainKey[chain.id],
     };
 
-    const quotes: ProviderQuoteDto[] = [];
     const kycLevels = (await this.supportedKycRepository.find({ where: { providerKey: this.meta.key, }, },))
       .map((e,) => e.kycLevel,);
 
@@ -299,14 +300,14 @@ export class KadoProvider implements IProvider {
       [response.data.request.fiatMethod]: response.data.quote ?? {},
     };
 
+    const quotesByPaymentMethod: PaymentMethodQuoteDto[] = [];
     Object.entries(responseQuotes,).forEach(([ _key, quote, ],) => {
       const paymentMethod = _key as KadoPaymentMethod;
       const mappedPaymentMethod = paymentMethods[paymentMethod];
       if (!options.paymentMethods.includes(mappedPaymentMethod,)) return;
 
-      const serializedQuote: Omit<ProviderQuoteDto, "steps"> = {
-        type: baseData.type,
-        provider: baseData.provider,
+      const serializedQuote: Omit<PaymentMethodQuoteDto, "steps"> = {
+        method: mappedPaymentMethod,
         pay: {
           currency: baseData.currency,
           fiatAmount: baseData.amount,
@@ -316,14 +317,12 @@ export class KadoProvider implements IProvider {
         },
         receive: {
           to: baseData.to,
-          token: baseData.token,
+          token: mapTokenPublicData(baseData.token,),
           chain: baseData.chain,
           amountUnits: parseUnits(quote.receive.unitCount.toString(), baseData.token.decimals,).toString(),
           amountFiat: quote.receive.unitCount * baseData.token.usdPrice,
         },
-        paymentMethods: mappedPaymentMethod ? [mappedPaymentMethod,] : [],
         kyc: kycLevels,
-        country: baseData.country,
       };
 
       const paymentLink = options.dev ? new URL("https://sandbox--kado.netlify.app/",) : new URL("https://app.kado.money",);
@@ -335,8 +334,8 @@ export class KadoProvider implements IProvider {
       paymentLink.searchParams.set("onToAddress", serializedQuote.receive.to,);
       paymentLink.searchParams.set("network", baseData.kadoChainKey,);
       paymentLink.searchParams.set("networkList", baseData.kadoChainKey,);
-      paymentLink.searchParams.set("product", serializedQuote.type,);
-      paymentLink.searchParams.set("productList", serializedQuote.type,);
+      paymentLink.searchParams.set("product", baseData.type,);
+      paymentLink.searchParams.set("productList", baseData.type,);
       paymentLink.searchParams.set("mode", "minimal",);
 
       const onrampViaLinkStep: QuoteStepOnrampViaLink = {
@@ -344,36 +343,19 @@ export class KadoProvider implements IProvider {
         link: paymentLink.href,
       };
 
-      quotes.push({
+      quotesByPaymentMethod.push({
         ...serializedQuote,
         steps: [onrampViaLinkStep,],
       },);
     },);
 
-    // Combine results if link is the same. In that case combine payment types and kyc.
-    // For pay/receive amounts, take the best "receive" option
-    const getOnrampStep = (quote: ProviderQuoteDto,) => {
-      const onrampStep = quote.steps.find((e,) => e.type === "onramp_via_link",)!;
-      return onrampStep;
+    const quoteDto: ProviderQuoteDto = {
+      type: options.routeType,
+      provider: this.meta,
+      country: options.country,
+      paymentMethods: quotesByPaymentMethod,
     };
 
-    // Combine results if link is the same. In that case combine payment types and kyc.
-    // For pay/receive amounts, take the best "receive" option
-    const combinedQuotes = quotes.reduce((acc, quote,) => {
-      const existing = acc.find((existingQuote,) => getOnrampStep(existingQuote,).link === getOnrampStep(quote,).link,);
-      if (!existing) return [ ...acc, quote, ];
-
-      existing.paymentMethods = Array.from(new Set([ ...existing.paymentMethods, ...quote.paymentMethods, ],),);
-      existing.kyc = Array.from(new Set([ ...existing.kyc, ...quote.kyc, ],),);
-      if (quote.receive.amountFiat > existing.receive.amountFiat) {
-        existing.receive = quote.receive;
-        existing.pay = quote.pay;
-        existing.steps = quote.steps;
-      }
-
-      return acc;
-    }, [] as ProviderQuoteDto[],);
-
-    return combinedQuotes;
+    return quoteDto;
   }
 }

--- a/packages/server/libs/providers/src/providers/transak/transak.provider.ts
+++ b/packages/server/libs/providers/src/providers/transak/transak.provider.ts
@@ -314,7 +314,7 @@ export class TransakProvider implements IProvider {
         quoteCountryCode: options.country,
       };
       let shouldBreak = false;
-      const quoteLink = `${TransakApiEndpoint()}/v1/pricing/public/quotes?${new URLSearchParams(removeUndefinedFields(quoteQuery,),)}`;
+      const quoteLink = `${TransakApiEndpoint(options.dev,)}/v1/pricing/public/quotes?${new URLSearchParams(removeUndefinedFields(quoteQuery,),)}`;
       const quote: TransakQuoteResponse | null = await $fetch(quoteLink,)
         .then((res,) => res.response,)
         .catch((error,) => {

--- a/packages/server/libs/providers/src/providers/transak/transak.provider.ts
+++ b/packages/server/libs/providers/src/providers/transak/transak.provider.ts
@@ -3,6 +3,7 @@ import {
 } from "@app/common/chains";
 import { FiatCurrency, } from "@app/common/currencies";
 import {
+  PaymentMethodQuoteDto,
   ProviderQuoteDto, QuoteOptions, QuoteStepOnrampViaLink,
 } from "@app/common/quotes";
 import { removeUndefinedFields, } from "@app/common/utils/helpers";
@@ -20,6 +21,7 @@ import {
   SupportedTokenRepository,
 } from "@app/db/repositories";
 import { TokensService, } from "@app/tokens";
+import { mapTokenPublicData, } from "@app/tokens/utils";
 import {
   Injectable, Logger, NotFoundException, 
 } from "@nestjs/common";
@@ -283,22 +285,22 @@ export class TransakProvider implements IProvider {
     }
   }
 
-  async getQuote(options: QuoteOptions,): Promise<ProviderQuoteDto[]> {
+  async getQuote(options: QuoteOptions,): Promise<ProviderQuoteDto | null> {
     const chain = supportedChains.find((c,) => c.id === options.chainId,)!;
     const networkKey = chainIdToTransakNetworkKey[chain.id];
     if (!networkKey) {
       this.logger.warn(`Chain ${chain.id} not mapped to Transak’s network`,);
-      return [];
+      return null;
     }
 
     if (options.fiatCurrency === MIN_BUY.fiatCurrency && options.fiatAmount < MIN_BUY.fiatAmount) {
       this.logger.debug(`[${this.meta.name}] Requested fiat amount ${options.fiatAmount} ${options.fiatCurrency} is below the minimum buy amount ${MIN_BUY.fiatAmount} ${MIN_BUY.fiatCurrency}`,);
-      return [];
+      return null;
     }
 
     const kycMethods = await this.getAvailableKycMethods.execute();
-    const quotes: ProviderQuoteDto[] = [];
-
+    
+    const quotesByPaymentMethod: PaymentMethodQuoteDto[] = [];
     for (const pm of options.paymentMethods) {
       const transakPaymentMethod = paymentMethodMap[pm];
       if (!transakPaymentMethod) continue;
@@ -321,7 +323,10 @@ export class TransakProvider implements IProvider {
           const message = (error as any)?.response?._data?.error?.message || (error as any)?.response?.message || error?.message || "Unknown error";
           this.logger.error(`Failed to fetch quote from ${this.meta.name} for ${quoteLink}. Error: ${message}`,);
           
-          const breakOnErrors: RegExp[] = [ /There are some limitation in your partner account/i, /Minimum\s+\w+\s+buy amount is/, ];
+          const breakOnErrors: RegExp[] = [
+            /There are some limitation in your partner account/i,
+            /Minimum\s+\w+\s+buy amount is/, // e.g. `Minimum ETH buy amount is 30`
+          ];
           if (breakOnErrors.some((e,) => e.test(message,),)) shouldBreak = true;
 
           return null;
@@ -346,22 +351,17 @@ export class TransakProvider implements IProvider {
       };
       const amountUnits = parseUnits(String(quote.cryptoAmount,), options.token.decimals,).toString();
       const amountFiat = quote.cryptoAmount * options.token.usdPrice;
+      if (amountFiat <= 0) continue;
 
-      const quoteDto: ProviderQuoteDto = {
-        type: options.routeType,
-        provider: this.meta,
+      quotesByPaymentMethod.push({
+        method: pm,
         pay: {
           currency: options.fiatCurrency,
           fiatAmount: options.fiatAmount,
           totalFeeFiat: quote.totalFee,
         },
         receive: {
-          token: {
-            address: options.token.address,
-            symbol: options.token.symbol,
-            name: options.token.name,
-            decimals: options.token.decimals,
-          },
+          token: mapTokenPublicData(options.token,),
           chain: {
             id: chain.id,
             name: chain.name,
@@ -370,16 +370,20 @@ export class TransakProvider implements IProvider {
           amountUnits: amountUnits,
           amountFiat,
         },
-        paymentMethods: [pm,],
         kyc: kycMethods,
         steps: [onrampStep,],
-        country: options.country,
-      };
-
-      quotes.push(quoteDto,);
+      },);
     }
+    if (!quotesByPaymentMethod.length) return null;
 
-    return quotes;
+    const quoteDto: ProviderQuoteDto = {
+      type: options.routeType,
+      provider: this.meta,
+      country: options.country,
+      paymentMethods: quotesByPaymentMethod,
+    };
+
+    return quoteDto;
   }
 
   private async fetchAccessToken(env: TransakEnvironment,): Promise<string> {

--- a/packages/server/libs/tokens/src/utils/index.ts
+++ b/packages/server/libs/tokens/src/utils/index.ts
@@ -1,6 +1,9 @@
+import type { Token, } from "@app/db/entities";
 import {
   type Address, formatUnits, parseUnits, 
 } from "viem";
+
+import type { TokenData, } from "..";
 
 export function formatMulticallError(error: Error,) {
   if (error.message
@@ -27,3 +30,14 @@ export type TokenKey = `${number}-${string}`;
 export function getTokenKey(token: { chainId: number; address: Address },) {
   return `${token.chainId}-${token.address}` as TokenKey;
 }
+
+export const mapTokenPublicData = (token: Token,): TokenData => ({
+  chainId: token.chainId,
+  address: token.address,
+  decimals: token.decimals,
+  symbol: token.symbol,
+  name: token.name,
+  marketCap: token.marketCap,
+  usdPrice: token.usdPrice,
+  iconUrl: token.iconUrl,
+});


### PR DESCRIPTION
# Description
Because some (probably even most) providers have a different onramp links and different quotes depending on the selected payment method we have to change the structure a bit.

What's changed:
Quote now doesn't have `steps`, `kyc`, `receive`, `pay`.
All these fields were moved to `quote.paymentMethods` array.