### PR TITLE
fix: route type missing properties

### DIFF
--- a/.changeset/slow-cows-doubt.md
+++ b/.changeset/slow-cows-doubt.md
@@ -1,0 +1,6 @@
+---
+"zksync-easy-onramp": patch
+---
+
+Fix properties for Route type.
+Properly include properties from ProviderQuoteOption in Route.

--- a/packages/sdk/src/types/sdk.ts
+++ b/packages/sdk/src/types/sdk.ts
@@ -82,7 +82,7 @@ export interface UnexecutedRoute extends Omit<ProviderQuoteOption, "paymentMetho
   steps: Step[]
 }
 
-export interface Route extends UnexecutedRoute {
+export interface Route extends Omit<ProviderQuoteOption, "paymentMethods"> {
   id: string
   status: "HALTING" | "HALTED" | "RUNNING" | "DONE";
   steps: StepExtended[]


### PR DESCRIPTION
# Description

Fix the type for Route so that it properly includes properties from ProviderQuoteOption.