### PR TITLE
chore: remove devxp from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These users are the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.
-* @JackHamer09 @itsacoyote @yuliyaalexiev @matter-labs/devxp
+* @JackHamer09 @itsacoyote @yuliyaalexiev
 
 # You can also specify code owners for specific directories or files.
 # For example:


### PR DESCRIPTION
# Description

DevEx currently does not own this repository, but being a part of codeowners creates a ton of notifications.

## Additional context
